### PR TITLE
Logging and configuration fixs

### DIFF
--- a/Metalama.Backstage.Commands/BaseAsyncCommand.cs
+++ b/Metalama.Backstage.Commands/BaseAsyncCommand.cs
@@ -27,22 +27,21 @@ public abstract class BaseAsyncCommand<T> : AsyncCommand<T>
 
         var extendedContext = new ExtendedCommandContext( context, settings, this.AddBackstageOptions );
         var logger = extendedContext.ServiceProvider.GetLoggerFactory().GetLogger( this.GetType().Name );
-        logger.Info?.Log( $"Executing command {this.GetType().Name}" );
+        logger.Trace?.Log( $"Executing command {this.GetType().Name}" );
 
         try
         {
             // We don't report usage of commands.
 
             await this.ExecuteAsync( extendedContext, settings );
-            logger.Info?.Log( $"The command succeeded." );
+            logger.Trace?.Log( $"The command succeeded." );
 
             return 0;
         }
         catch ( CommandException e )
         {
-            extendedContext.Console.WriteError( e.Message );
-            logger.Warning?.Log( $"The command returned {e.ReturnCode}: {e.Message}." );
-
+            logger.Error?.Log( e.Message );
+            
             return e.ReturnCode;
         }
         catch ( Exception e )

--- a/Metalama.Backstage.Commands/BaseCommand.cs
+++ b/Metalama.Backstage.Commands/BaseCommand.cs
@@ -26,21 +26,19 @@ namespace Metalama.Backstage.Commands
 
             var extendedContext = new ExtendedCommandContext( context, settings, this.AddBackstageOptions );
             var logger = extendedContext.ServiceProvider.GetLoggerFactory().GetLogger( this.GetType().Name );
-            logger.Info?.Log( $"Executing command {this.GetType().Name}" );
+            logger.Trace?.Log( $"Executing command {this.GetType().Name}" );
 
             try
             {
                 // We don't report usage of commands.
 
                 this.Execute( extendedContext, settings );
-                logger.Info?.Log( $"The command succeeded." );
-
+                
                 return 0;
             }
             catch ( CommandException e )
             {
-                extendedContext.Console.WriteError( e.Message );
-                logger.Warning?.Log( $"The command returned {e.ReturnCode}: {e.Message}." );
+                logger.Error?.Log( e.Message );
 
                 return e.ReturnCode;
             }

--- a/Metalama.Backstage.Commands/CommandServiceProvider.cs
+++ b/Metalama.Backstage.Commands/CommandServiceProvider.cs
@@ -28,8 +28,8 @@ namespace Metalama.Backstage.Commands
             var serviceProviderBuilder = new ServiceProviderBuilder(
                 ( type, func ) => serviceCollection.Add( new ServiceDescriptor( type, func, ServiceLifetime.Singleton ) ) );
 
-            var loggerFactory = serviceCollection.BuildServiceProvider().GetLoggerFactory();
             serviceProviderBuilder.AddService( typeof(ILoggerFactory), new AnsiConsoleLoggerFactory( args.Console, args.Settings ) );
+            var loggerFactory = serviceCollection.BuildServiceProvider().GetLoggerFactory();
 
             var initializationOptions = new BackstageInitializationOptions( this._applicationInfo )
             {

--- a/Metalama.Backstage.Desktop.Windows/Commands/BaseAsyncCommand.cs
+++ b/Metalama.Backstage.Desktop.Windows/Commands/BaseAsyncCommand.cs
@@ -17,13 +17,12 @@ public abstract class BaseAsyncCommand<T> : AsyncCommand<T>
         var serviceProvider = App.GetBackstageServices( settings );
         var loggerFactory = serviceProvider.GetLoggerFactory();
         var logger = loggerFactory.GetLogger( this.GetType().Name );
-        logger.Info?.Log( $"Executing command {this.GetType().Name}" );
+        logger.Trace?.Log( $"Executing command {this.GetType().Name}" );
 
         try
         {
             var result = await this.ExecuteAsync( new ExtendedCommandContext( context, serviceProvider, logger ), settings );
-            logger.Info?.Log( $"The command returned {result}." );
-
+            
             return result;
         }
         catch ( Exception e )

--- a/Metalama.Backstage.Desktop.Windows/Commands/BaseCommand.cs
+++ b/Metalama.Backstage.Desktop.Windows/Commands/BaseCommand.cs
@@ -16,13 +16,12 @@ public abstract class BaseCommand<T> : Command<T>
         var serviceProvider = App.GetBackstageServices( settings );
         var loggerFactory = serviceProvider.GetLoggerFactory();
         var logger = loggerFactory.GetLogger( this.GetType().Name );
-        logger.Info?.Log( $"Executing command {this.GetType().Name}" );
+        logger.Trace?.Log( $"Executing command {this.GetType().Name}" );
 
         try
         {
             var result = this.Execute( new ExtendedCommandContext( context, serviceProvider, logger ), settings );
-            logger.Info?.Log( $"The command returned {result}." );
-
+            
             return result;
         }
         catch ( Exception e )

--- a/Metalama.Backstage/Configuration/ConfigurationFile.cs
+++ b/Metalama.Backstage/Configuration/ConfigurationFile.cs
@@ -8,22 +8,30 @@ namespace Metalama.Backstage.Configuration;
 
 public abstract record ConfigurationFile
 {
-    private DateTime? _lastModified;
+    private DateTime? _fileSystemTimestamp;
 
-    [JsonIgnore]
-    internal DateTime? LastModified
+    /// <summary>
+    /// Gets a distinct timestamp for the current object.
+    /// </summary>
+    internal ConfigurationFileTimestamp? Timestamp
+        => this._fileSystemTimestamp == null ? null : new ConfigurationFileTimestamp( this._fileSystemTimestamp.Value, this.Version );
+
+    internal void SetFilesystemTimestamp( DateTime value )
     {
-        get => this._lastModified;
-        set
-        {
-            if ( value != null && value.Value.Kind != DateTimeKind.Local )
-            {
-                throw new ArgumentOutOfRangeException( nameof(value), "A local time was expected." );
-            }
-
-            this._lastModified = value;
-        }
+        this._fileSystemTimestamp = value.ToUniversalTime();
     }
+
+    internal void IncrementVersion()
+    {
+        this.Version = (this.Version ?? 0) + 1;
+    }
+
+    /// <summary>
+    /// Gets or sets a version number of this object.  We don't expect the user (or other versions of Metalama.Backstage) to change this property.
+    /// Its value is only taken into account when comparing two objects with the same filesystem timestamp.
+    /// </summary>
+    [JsonProperty( "version" )]
+    public int? Version { get; set; }
 
     public string ToJson()
     {
@@ -35,6 +43,9 @@ public abstract record ConfigurationFile
 
         return textWriter.ToString();
     }
+
+    internal bool StructurallyEqualsTo( ConfigurationFile other )
+        => (this with { Version = null }).ToJson().Equals( (other with { Version = null }).ToJson(), StringComparison.Ordinal );
 
     public virtual void Validate( Action<string> reportWarning ) { }
 }

--- a/Metalama.Backstage/Configuration/ConfigurationFile.cs
+++ b/Metalama.Backstage/Configuration/ConfigurationFile.cs
@@ -8,8 +8,22 @@ namespace Metalama.Backstage.Configuration;
 
 public abstract record ConfigurationFile
 {
+    private DateTime? _lastModified;
+
     [JsonIgnore]
-    internal DateTime? LastModified { get; set; }
+    internal DateTime? LastModified
+    {
+        get => this._lastModified;
+        set
+        {
+            if ( value != null && value.Value.Kind != DateTimeKind.Local )
+            {
+                throw new ArgumentOutOfRangeException( nameof(value), "A local time was expected." );
+            }
+
+            this._lastModified = value;
+        }
+    }
 
     public string ToJson()
     {

--- a/Metalama.Backstage/Configuration/ConfigurationFileTimestamp.cs
+++ b/Metalama.Backstage/Configuration/ConfigurationFileTimestamp.cs
@@ -1,0 +1,53 @@
+// Copyright (c) SharpCrafters s.r.o. See the LICENSE.md file in the root directory of this repository root for details.
+
+using System;
+using System.Globalization;
+
+namespace Metalama.Backstage.Configuration;
+
+public readonly struct ConfigurationFileTimestamp : IEquatable<ConfigurationFileTimestamp>
+{
+    private readonly DateTime _lastModificationTime;
+    private readonly int _version;
+
+    internal ConfigurationFileTimestamp( DateTime lastModificationTime, int? version )
+    {
+        if ( lastModificationTime.Kind != DateTimeKind.Utc )
+        {
+            throw new ArgumentOutOfRangeException( nameof(lastModificationTime), "A local timestamp was expected." );
+        }
+
+        this._lastModificationTime = lastModificationTime;
+        this._version = version ?? 0;
+    }
+
+    public DateTime ToUtcDateTime() => this._lastModificationTime;
+
+    public override string ToString() => this._lastModificationTime.ToString( CultureInfo.InvariantCulture ) + ":" + this._version;
+
+    public bool Equals( ConfigurationFileTimestamp other ) => this._lastModificationTime == other._lastModificationTime && this._version == other._version;
+
+    public override bool Equals( object? obj ) => obj is ConfigurationFileTimestamp other && this.Equals( other );
+
+    public override int GetHashCode() => HashCode.Combine( this._lastModificationTime, this._version );
+
+    public static bool operator ==( ConfigurationFileTimestamp left, ConfigurationFileTimestamp right ) => left.Equals( right );
+
+    public static bool operator !=( ConfigurationFileTimestamp left, ConfigurationFileTimestamp right ) => !left.Equals( right );
+
+    public bool IsOlderThan( in ConfigurationFileTimestamp other )
+    {
+        if ( this._lastModificationTime == other._lastModificationTime )
+        {
+            return this._version < other._version;
+        }
+        else if ( this._lastModificationTime < other._lastModificationTime )
+        {
+            return true;
+        }
+        else
+        {
+            return false;
+        }
+    }
+}

--- a/Metalama.Backstage/Configuration/ConfigurationFileTimestamp.cs
+++ b/Metalama.Backstage/Configuration/ConfigurationFileTimestamp.cs
@@ -14,7 +14,7 @@ public readonly struct ConfigurationFileTimestamp : IEquatable<ConfigurationFile
     {
         if ( lastModificationTime.Kind != DateTimeKind.Utc )
         {
-            throw new ArgumentOutOfRangeException( nameof(lastModificationTime), "A local timestamp was expected." );
+            throw new ArgumentOutOfRangeException( nameof(lastModificationTime), "A UTC timestamp was expected." );
         }
 
         this._lastModificationTime = lastModificationTime;

--- a/Metalama.Backstage/Configuration/ConfigurationManager.cs
+++ b/Metalama.Backstage/Configuration/ConfigurationManager.cs
@@ -104,7 +104,7 @@ namespace Metalama.Backstage.Configuration
                                 foreach ( var oldSetting in oldSettings )
                                 {
                                     if ( this.TryLoadConfigurationFile( oldSetting.GetType(), out var newSetting ) &&
-                                         (oldSetting.LastModified == null || newSetting.LastModified > oldSetting.LastModified + _lastModifiedTolerance) )
+                                         (oldSetting.Timestamp == null || oldSetting.Timestamp.Value.IsOlderThan( newSetting.Timestamp!.Value )) )
                                     {
                                         this.AddToCache( newSetting );
                                     }
@@ -200,48 +200,66 @@ namespace Metalama.Backstage.Configuration
 
         private void AddToCache( ConfigurationFile settings )
         {
-            var isChange = this._instances.TryGetValue( settings.GetType(), out var oldValue ) && oldValue.ToJson() != settings.ToJson();
+            var isChange = this._instances.TryGetValue( settings.GetType(), out var oldValue ) && !oldValue.StructurallyEqualsTo( settings );
 
+            // We always update the cache even if there is no structural change to make sure we have the latest version number.
             this._instances.AddOrUpdate( settings.GetType(), settings, ( _, _ ) => settings );
 
+            // However, we only raise the event when there is a change.
             if ( isChange )
             {
                 this.ConfigurationFileChanged?.Invoke( settings );
             }
         }
 
-        public bool TryUpdate( ConfigurationFile value, DateTime? lastModified )
+        public bool TryUpdate( ConfigurationFile value, ConfigurationFileTimestamp? expectedTimestamp )
         {
-            if ( lastModified != null && lastModified.Value.Kind != DateTimeKind.Local )
-            {
-                throw new ArgumentOutOfRangeException( nameof(lastModified), "A local time was expected." );
-            }
-
             using ( this.WithMutex() )
             {
                 var type = value.GetType();
                 var fileName = this.GetFilePath( type );
 
-                this.Logger.Trace?.Log( $"Trying to update '{fileName}'. Our last timestamp is '{lastModified:O}'." );
+                this.Logger.Trace?.Log( $"Trying to update '{fileName}'. Our last timestamp is '{expectedTimestamp}'." );
 
                 // Verify (inside the global lock) that we have a fresh copy of the file.
-                if ( lastModified == null )
+                if ( expectedTimestamp == null )
                 {
                     if ( this._fileSystem.FileExists( fileName ) )
                     {
+                        this.Logger.Warning?.Log( $"Cannot update '{fileName}' because the file exists but was not expected to exist." );
+
                         return false;
                     }
                 }
-                else if ( !this._fileSystem.FileExists( fileName ) || this._fileSystem.GetFileLastWriteTime( fileName ) != lastModified )
+                else
                 {
-                    this.Logger.Warning?.Log( $"Cannot update '{fileName}' because the file did not exists or had a different timestamp." );
+                    if ( !this._fileSystem.FileExists( fileName ) )
+                    {
+                        this.Logger.Warning?.Log( $"Cannot update '{fileName}' because the file does not exists but was expected to exist." );
 
-                    return false;
+                        return false;
+                    }
+
+                    var existingFile = this.Get( value.GetType(), true );
+
+                    if ( existingFile.Timestamp!.Value != expectedTimestamp.Value )
+                    {
+                        this.Logger.Warning?.Log(
+                            $"Cannot update '{fileName}' because the file has a different timestamp than expected: {existingFile.Timestamp} instead of {expectedTimestamp.Value}." );
+
+                        return false;
+                    }
+
+                    // We must wait until the clock returns a different value than the current one.
+                    while ( this._dateTimeProvider.UtcNow == existingFile.Timestamp.Value.ToUtcDateTime() )
+                    {
+                        Thread.Sleep( 1 );
+                    }
                 }
 
                 if ( this._instances.TryGetValue( type, out var originalSettings ) )
                 {
-                    if ( lastModified.HasValue && originalSettings.LastModified != lastModified.Value )
+                    if ( expectedTimestamp.HasValue && originalSettings.Timestamp != expectedTimestamp.Value )
                     {
                         this.Logger.Warning?.Log( $"Cannot update '{fileName}' because our cached copy does not have the latest timestamp." );
 
@@ -249,28 +267,16 @@ namespace Metalama.Backstage.Configuration
                     }
                 }
 
+                value.IncrementVersion();
                 var json = value.ToJson();
 
                 RetryHelper.Retry( () => this._fileSystem.WriteAllText( fileName, json ) );
 
                 var newLastModified = this._fileSystem.GetFileLastWriteTime( fileName );
-
-                while ( newLastModified == lastModified )
-                {
-                    // The new filesystem timestamp is identical to the previous one, so we have to wait until there is an observable
-                    // difference in the timestamp.
-
-                    this.Logger.Trace?.Log( "Waiting for " );
-                    Thread.Sleep( 10 );
-                    this._fileSystem.SetFileLastWriteTime( fileName, this._dateTimeProvider.UtcNow );
-                    newLastModified = this._fileSystem.GetFileLastWriteTime( fileName );
-                }
-
-                value = value with { LastModified = newLastModified };
-
+                value.SetFilesystemTimestamp( newLastModified );
                 this.AddToCache( value );
 
-                this.Logger.Trace?.Log( $"File '{fileName}' updated. The new timestamp is '{newLastModified:O}'." );
+                this.Logger.Trace?.Log( $"File '{fileName}' updated. The new timestamp is '{value.Timestamp}'." );
             }
 
             return true;
@@ -353,7 +359,7 @@ namespace Metalama.Backstage.Configuration
                     settings.Validate( message => this.Logger.Warning?.Log( $"Recoverable error in '{fileName}: {message}'" ) );
                 }
 
-                settings = settings with { LastModified = lastModified };
+                settings.SetFilesystemTimestamp( lastModified );
 
                 return true;
             }
@@ -365,7 +371,7 @@ namespace Metalama.Backstage.Configuration
                 // with the LastModified property properly set. If instead we return false, the caller
                 // will interpret this as if the file did not exist, and it can create an infinite loop.
                 settings = (ConfigurationFile) Activator.CreateInstance( type )!;
-                settings.LastModified = lastModified;
+                settings.SetFilesystemTimestamp( lastModified );
 
                 return true;
             }

--- a/Metalama.Backstage/Configuration/ConfigurationManager.cs
+++ b/Metalama.Backstage/Configuration/ConfigurationManager.cs
@@ -20,8 +20,6 @@ namespace Metalama.Backstage.Configuration
 {
     internal sealed class ConfigurationManager : IConfigurationManager
     {
-        private static readonly TimeSpan _lastModifiedTolerance = TimeSpan.FromSeconds( 0.2 );
-
         // Stores the in-memory configuration object. Note that ConfigurationFile can be implemented in a different assembly, and that
         // there may be several copies of this assembly in the current AppDomain. Therefore, this dictionary may contain several objects
         // that represent the same file.

--- a/Metalama.Backstage/Configuration/ConfigurationManager.cs
+++ b/Metalama.Backstage/Configuration/ConfigurationManager.cs
@@ -141,24 +141,18 @@ namespace Metalama.Backstage.Configuration
 
         public string GetFilePath( Type type )
         {
-            var attribute = type.GetCustomAttribute<ConfigurationFileAttribute>();
-
-            if ( attribute == null )
-            {
-                throw new InvalidOperationException( $"'{nameof(ConfigurationFileAttribute)}' custom attribute not found for '{type.FullName}' type." );
-            }
+            var attribute = type.GetCustomAttribute<ConfigurationFileAttribute>()
+                            ?? throw new InvalidOperationException(
+                                $"'{nameof(ConfigurationFileAttribute)}' custom attribute not found for '{type.FullName}' type." );
 
             return this.GetFilePath( attribute.FileName );
         }
 
         private string? GetEnvironmentVariableName( Type type )
         {
-            var attribute = type.GetCustomAttribute<ConfigurationFileAttribute>();
-
-            if ( attribute == null )
-            {
-                throw new InvalidOperationException( $"'{nameof(ConfigurationFileAttribute)}' custom attribute not found for '{type.FullName}' type." );
-            }
+            var attribute = type.GetCustomAttribute<ConfigurationFileAttribute>()
+                            ?? throw new InvalidOperationException(
+                                $"'{nameof(ConfigurationFileAttribute)}' custom attribute not found for '{type.FullName}' type." );
 
             return attribute.EnvironmentVariableName;
         }
@@ -176,12 +170,8 @@ namespace Metalama.Backstage.Configuration
                         return value;
                     }
 
-                    var settingsObject = Activator.CreateInstance( type );
-
-                    if ( settingsObject == null )
-                    {
-                        throw new InvalidOperationException( $"Failed to create instance of '{type.FullName}' type." );
-                    }
+                    var settingsObject = Activator.CreateInstance( type )
+                                         ?? throw new InvalidOperationException( $"Failed to create instance of '{type.FullName}' type." );
 
                     var settings = (ConfigurationFile) settingsObject;
 
@@ -222,6 +212,11 @@ namespace Metalama.Backstage.Configuration
 
         public bool TryUpdate( ConfigurationFile value, DateTime? lastModified )
         {
+            if ( lastModified != null && lastModified.Value.Kind != DateTimeKind.Local )
+            {
+                throw new ArgumentOutOfRangeException( nameof(lastModified), "A local time was expected." );
+            }
+
             using ( this.WithMutex() )
             {
                 var type = value.GetType();

--- a/Metalama.Backstage/Configuration/ConfigurationManagerExtensions.cs
+++ b/Metalama.Backstage/Configuration/ConfigurationManagerExtensions.cs
@@ -22,12 +22,12 @@ namespace Metalama.Backstage.Configuration
             where T : ConfigurationFile
         {
             // Do a first check that does not skip the cache.
-            if ( configurationManager.Get<T>().LastModified != null )
+            if ( configurationManager.Get<T>().Timestamp != null )
             {
                 return false;
             }
 
-            return configurationManager.UpdateIf<T>( c => !c.LastModified.HasValue, c => c );
+            return configurationManager.UpdateIf<T>( c => !c.Timestamp.HasValue, c => c );
         }
 
         public static bool UpdateIf<T>( this IConfigurationManager configurationManager, Predicate<T> condition, Func<T, T> updateFunc )
@@ -67,14 +67,14 @@ namespace Metalama.Backstage.Configuration
 
                 newSettings = updateFunc( originalSettings );
 
-                if ( originalSettings.LastModified.HasValue && newSettings.Equals( originalSettings ) )
+                if ( originalSettings.Timestamp.HasValue && newSettings.Equals( originalSettings ) )
                 {
                     configurationManager.Logger.Trace?.Log( $"Update of {typeof(T).Name} skipped because no change was required." );
 
                     return false;
                 }
             }
-            while ( !configurationManager.TryUpdate( newSettings, originalSettings.LastModified ) );
+            while ( !configurationManager.TryUpdate( newSettings, originalSettings.Timestamp ) );
 
             return true;
         }
@@ -108,14 +108,14 @@ namespace Metalama.Backstage.Configuration
 
                 newSettings = updateFunc( originalSettings );
 
-                if ( originalSettings.LastModified.HasValue && newSettings.Equals( originalSettings ) )
+                if ( originalSettings.Timestamp.HasValue && newSettings.Equals( originalSettings ) )
                 {
                     configurationManager.Logger.Trace?.Log( $"Update of {typeof(T).Name} skipped because no change was required." );
 
                     return false;
                 }
             }
-            while ( !configurationManager.TryUpdate( newSettings, originalSettings.LastModified ) );
+            while ( !configurationManager.TryUpdate( newSettings, originalSettings.Timestamp ) );
 
             return true;
         }

--- a/Metalama.Backstage/Configuration/IConfigurationManager.cs
+++ b/Metalama.Backstage/Configuration/IConfigurationManager.cs
@@ -22,8 +22,8 @@ namespace Metalama.Backstage.Configuration
         /// Try to update a settings file if the base revision matches the expected value.
         /// </summary>
         /// <param name="value"></param>
-        /// <param name="lastModified"></param>
+        /// <param name="expectedTimestamp"></param>
         /// <returns></returns>
-        bool TryUpdate( ConfigurationFile value, DateTime? lastModified );
+        bool TryUpdate( ConfigurationFile value, ConfigurationFileTimestamp? expectedTimestamp );
     }
 }

--- a/Metalama.Backstage/Configuration/InMemoryConfigurationManager.cs
+++ b/Metalama.Backstage/Configuration/InMemoryConfigurationManager.cs
@@ -62,7 +62,7 @@ public class InMemoryConfigurationManager : IConfigurationManager
                 return false;
             }
 
-            value = value with { LastModified = this._timeProvider.UtcNow };
+            value = value with { LastModified = this._timeProvider.UtcNow.ToLocalTime() };
             this._files[value.GetType()] = value;
             this.ConfigurationFileChanged?.Invoke( value );
 

--- a/Metalama.Backstage/Configuration/InMemoryConfigurationManager.cs
+++ b/Metalama.Backstage/Configuration/InMemoryConfigurationManager.cs
@@ -62,7 +62,7 @@ public class InMemoryConfigurationManager : IConfigurationManager
                 return false;
             }
 
-            value.SetFilesystemTimestamp( this._timeProvider.UtcNow.ToLocalTime() );
+            value.SetFilesystemTimestamp( this._timeProvider.UtcNow );
             this._files[value.GetType()] = value;
             this.ConfigurationFileChanged?.Invoke( value );
 

--- a/Metalama.Backstage/Configuration/InMemoryConfigurationManager.cs
+++ b/Metalama.Backstage/Configuration/InMemoryConfigurationManager.cs
@@ -51,18 +51,18 @@ public class InMemoryConfigurationManager : IConfigurationManager
 
     public event Action<ConfigurationFile>? ConfigurationFileChanged;
 
-    public bool TryUpdate( ConfigurationFile value, DateTime? lastModified )
+    public bool TryUpdate( ConfigurationFile value, ConfigurationFileTimestamp? expectedTimestamp )
     {
         lock ( this )
         {
             var oldFile = this.Get( value.GetType() );
 
-            if ( oldFile.LastModified != lastModified )
+            if ( oldFile.Timestamp != expectedTimestamp )
             {
                 return false;
             }
 
-            value = value with { LastModified = this._timeProvider.UtcNow.ToLocalTime() };
+            value.SetFilesystemTimestamp( this._timeProvider.UtcNow.ToLocalTime() );
             this._files[value.GetType()] = value;
             this.ConfigurationFileChanged?.Invoke( value );
 

--- a/Metalama.Backstage/Diagnostics/LogFileWriter.cs
+++ b/Metalama.Backstage/Diagnostics/LogFileWriter.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) SharpCrafters s.r.o. See the LICENSE.md file in the root directory of this repository root for details.
 
 using Metalama.Backstage.Infrastructure;
-using Metalama.Backstage.Utilities;
 using System;
 using System.Collections.Concurrent;
 using System.Diagnostics;
@@ -36,15 +35,6 @@ internal class LogFileWriter
 
         try
         {
-            RetryHelper.Retry(
-                () =>
-                {
-                    if ( !this._fileSystem.DirectoryExists( loggerFactory.LogDirectory ) )
-                    {
-                        this._fileSystem.CreateDirectory( loggerFactory.LogDirectory! );
-                    }
-                } );
-
             var scopeWithDash = string.IsNullOrEmpty( scope ) ? "" : "-" + scope;
 
             // The filename must be unique because several instances of the current assembly (of different versions) may be loaded in the process.
@@ -64,7 +54,7 @@ internal class LogFileWriter
         {
             return;
         }
-        
+
         if ( this._disposing )
         {
             this._backgroundTaskStatus = _inactiveStatus;

--- a/Metalama.Backstage/Diagnostics/Logger.cs
+++ b/Metalama.Backstage/Diagnostics/Logger.cs
@@ -10,22 +10,21 @@ internal class Logger : ILogger
 
     public string Prefix { get; }
 
-    public Logger( LoggerFactory loggerDiagnosticsService, string category, string prefix = "" )
+    public Logger( LoggerFactory loggerFactory, string category, string prefix = "" )
     {
         this.Prefix = prefix;
-        this.LoggerFactory = loggerDiagnosticsService;
+        this.LoggerFactory = loggerFactory;
         this.Category = category;
-        this.Error = this.CreateLogWriter( "ERROR" );
-        this.Warning = this.CreateLogWriter( "WARNING" );
-        this.Info = this.CreateLogWriter( "INFO" );
+        this.Error = this.CreateLogWriter( "ERROR", true );
+        this.Warning = this.CreateLogWriter( "WARNING", loggerFactory.ShouldLogWarningsAndInfos );
+        this.Info = this.CreateLogWriter( "INFO", loggerFactory.ShouldLogWarningsAndInfos );
 
-        if ( this.LoggerFactory.Configuration.Logging.IsTraceCategoryEnabled( category ) )
-        {
-            this.Trace = this.CreateLogWriter( "TRACE" );
-        }
+        this.Trace = this.CreateLogWriter(
+            "TRACE",
+            loggerFactory.ShouldLogWarningsAndInfos && this.LoggerFactory.Configuration.Logging.IsTraceCategoryEnabled( category ) );
     }
 
-    private LogWriter? CreateLogWriter( string logLevel ) => new( this, logLevel );
+    private LogWriter? CreateLogWriter( string logLevel, bool isEnabled ) => isEnabled ? new LogWriter( this, logLevel ) : null;
 
     public ILogWriter? Trace { get; }
 

--- a/Metalama.Backstage/Diagnostics/LoggerFactory.cs
+++ b/Metalama.Backstage/Diagnostics/LoggerFactory.cs
@@ -63,9 +63,7 @@ namespace Metalama.Backstage.Diagnostics
             }
             else
             {
-                logger = new Logger( this, category );
-
-                return this._loggers.GetOrAdd( category, logger );
+                return this._loggers.GetOrAdd( category, c => new Logger( this, c ) );
             }
         }
 

--- a/Metalama.Backstage/Extensibility/RegisterServiceExtensions.cs
+++ b/Metalama.Backstage/Extensibility/RegisterServiceExtensions.cs
@@ -72,8 +72,9 @@ public static class RegisterServiceExtensions
                 else
                 {
                     // Automatically stop logging after a while.
-                    if ( configuration.LastModified != null &&
-                         configuration.LastModified < dateTimeProvider.UtcNow.AddHours( -configuration.Logging.StopLoggingAfterHours ) )
+                    var lastAcceptableModificationTime = dateTimeProvider.UtcNow.AddHours( -configuration.Logging.StopLoggingAfterHours );
+
+                    if ( configuration.LastModified != null && configuration.LastModified.Value.ToUniversalTime() < lastAcceptableModificationTime )
                     {
                         configurationManager.UpdateIf<DiagnosticsConfiguration>(
                             c => c.Logging.Processes.Any( p => p.Value ),

--- a/Metalama.Backstage/Extensibility/RegisterServiceExtensions.cs
+++ b/Metalama.Backstage/Extensibility/RegisterServiceExtensions.cs
@@ -74,7 +74,7 @@ public static class RegisterServiceExtensions
                     // Automatically stop logging after a while.
                     var lastAcceptableModificationTime = dateTimeProvider.UtcNow.AddHours( -configuration.Logging.StopLoggingAfterHours );
 
-                    if ( configuration.LastModified != null && configuration.LastModified.Value.ToUniversalTime() < lastAcceptableModificationTime )
+                    if ( configuration.Timestamp != null && configuration.Timestamp.Value.ToUtcDateTime() < lastAcceptableModificationTime )
                     {
                         configurationManager.UpdateIf<DiagnosticsConfiguration>(
                             c => c.Logging.Processes.Any( p => p.Value ),

--- a/Metalama.Backstage/UserInterface/UserInterfaceService.cs
+++ b/Metalama.Backstage/UserInterface/UserInterfaceService.cs
@@ -88,7 +88,7 @@ public abstract class UserInterfaceService : IUserInterfaceService
 
         var stopwatch = Stopwatch.StartNew();
 
-        this.Logger.Info?.Log( "Waiting for the HTTP server." );
+        this.Logger.Trace?.Log( "Waiting for the HTTP server." );
 
         while ( true )
         {

--- a/Tests/Metalama.Backstage.Commands.Tests/Commands/CommandsTestsBase.cs
+++ b/Tests/Metalama.Backstage.Commands.Tests/Commands/CommandsTestsBase.cs
@@ -26,36 +26,27 @@ namespace Metalama.Tools.Config.Tests.Commands
         protected Task TestCommandAsync(
             string commandLine,
             string? expectedOutput = null,
-            string? expectedError = null,
             int expectedExitCode = 0 )
-            => this.TestCommandAsync( commandLine.Split( ' ' ), expectedOutput, expectedError, expectedExitCode );
+            => this.TestCommandAsync( commandLine.Split( ' ' ), expectedOutput, expectedExitCode );
 
         protected async Task TestCommandAsync(
             string[] commandLine,
             string? expectedOutput = null,
-            string? expectedError = null,
             int expectedExitCode = 0 )
         {
-            var standardOutput = new StringWriter();
-            var errorOutput = new StringWriter();
+            var output = new StringWriter();
+
+            this.Log.MessageReported += output.WriteLine;
 
             this._logger.Trace?.Log( $">> {string.Join( " ", commandLine )}" );
 
             var commandApp = new CommandApp();
-            BackstageCommandFactory.ConfigureCommandApp( commandApp, new BackstageCommandOptions( this, standardOutput, errorOutput, AnsiSupport.No ) );
+            BackstageCommandFactory.ConfigureCommandApp( commandApp, new BackstageCommandOptions( this, output, output, AnsiSupport.No ) );
             var exitCode = await commandApp.RunAsync( commandLine );
-
-            this._logger.Trace?.Log( standardOutput.ToString() );
-            this._logger.Trace?.Log( errorOutput.ToString() );
 
             if ( expectedOutput != null )
             {
-                Assert.Contains( expectedOutput, standardOutput.ToString(), StringComparison.OrdinalIgnoreCase );
-            }
-
-            if ( expectedError != null )
-            {
-                Assert.Contains( expectedError, errorOutput.ToString(), StringComparison.OrdinalIgnoreCase );
+                Assert.Contains( expectedOutput, output.ToString(), StringComparison.OrdinalIgnoreCase );
             }
 
             Assert.Equal( expectedExitCode, exitCode );

--- a/Tests/Metalama.Backstage.Commands.Tests/Commands/Licensing/RegisterTrialCommandTests.cs
+++ b/Tests/Metalama.Backstage.Commands.Tests/Commands/Licensing/RegisterTrialCommandTests.cs
@@ -39,7 +39,6 @@ namespace Metalama.Tools.Config.Tests.Commands.Licensing
 
             await this.TestCommandAsync(
                 "license try",
-                null,
                 $"You cannot start a new trial period until {_evaluationStart.AddDays( 120 + 45 ).ToString( CultureInfo.CurrentCulture )}.",
                 1 );
 

--- a/Tests/Metalama.Backstage.Commands.Tests/Commands/Licensing/UnregisterCommandTests.cs
+++ b/Tests/Metalama.Backstage.Commands.Tests/Commands/Licensing/UnregisterCommandTests.cs
@@ -17,7 +17,6 @@ namespace Metalama.Tools.Config.Tests.Commands.Licensing
         {
             await this.TestCommandAsync(
                 $"license unregister",
-                "",
                 $"A license is not registered." + Environment.NewLine,
                 1 );
         }

--- a/Tests/Metalama.Backstage.Testing/TestDateTimeProvider.cs
+++ b/Tests/Metalama.Backstage.Testing/TestDateTimeProvider.cs
@@ -11,7 +11,7 @@ namespace Metalama.Backstage.Testing
         private DateTime? _lastResetTime;
         private Stopwatch? _stopwatch;
 
-        public DateTime UtcNow => this._lastResetTime?.ToUniversalTime().AddMilliseconds( this._stopwatch?.ElapsedMilliseconds ?? 0 ) ?? DateTime.UtcNow;
+        public DateTime UtcNow => this._lastResetTime?.AddMilliseconds( this._stopwatch?.ElapsedMilliseconds ?? 0 ) ?? DateTime.UtcNow;
 
         public void Stop() => this.Set( DateTime.UtcNow );
 

--- a/Tests/Metalama.Backstage.Testing/TestDateTimeProvider.cs
+++ b/Tests/Metalama.Backstage.Testing/TestDateTimeProvider.cs
@@ -11,7 +11,9 @@ namespace Metalama.Backstage.Testing
         private DateTime? _lastResetTime;
         private Stopwatch? _stopwatch;
 
-        public DateTime UtcNow => this._lastResetTime?.AddMilliseconds( this._stopwatch?.ElapsedMilliseconds ?? 0 ) ?? DateTime.UtcNow;
+        public DateTime UtcNow => this._lastResetTime?.ToUniversalTime().AddMilliseconds( this._stopwatch?.ElapsedMilliseconds ?? 0 ) ?? DateTime.UtcNow;
+
+        public void Stop() => this.Set( DateTime.UtcNow );
 
         public void Set( DateTime now, bool keepRunning = false )
         {

--- a/Tests/Metalama.Backstage.Testing/TestLoggerFactory.cs
+++ b/Tests/Metalama.Backstage.Testing/TestLoggerFactory.cs
@@ -35,7 +35,7 @@ public class TestLoggerFactory : ILoggerFactory
     }
 
     public IReadOnlyList<Entry> Entries => this._entries;
-    
+
     public ILogger GetLogger( string category ) => this._loggers.GetOrAdd( category, c => new Logger( c, this ) );
 
     public void Flush() { }
@@ -88,7 +88,14 @@ public class TestLoggerFactory : ILoggerFactory
                 this._parent._entries = this._parent._entries.Add( new Entry( this._severity, message ) );
             }
 
-            this._parent._testOutputHelper.WriteLine( $"{this._severity.ToString().ToUpperInvariant()} {this._category}: {message}" );
+            try
+            {
+                this._parent._testOutputHelper.WriteLine( $"{this._severity.ToString().ToUpperInvariant()} {this._category}: {message}" );
+            }
+            catch
+            {
+                // There can be an exception if a message is reported during after the test finishes.
+            }
         }
     }
 

--- a/Tests/Metalama.Backstage.Testing/TestLoggerFactory.cs
+++ b/Tests/Metalama.Backstage.Testing/TestLoggerFactory.cs
@@ -42,6 +42,8 @@ public class TestLoggerFactory : ILoggerFactory
 
     public IDisposable EnterScope( string scope ) => default(DisposableAction);
 
+    public event Action<string>? MessageReported;
+
     private class Logger : ILogger
     {
         private readonly string _category;
@@ -90,7 +92,9 @@ public class TestLoggerFactory : ILoggerFactory
 
             try
             {
-                this._parent._testOutputHelper.WriteLine( $"{this._severity.ToString().ToUpperInvariant()} {this._category}: {message}" );
+                var formatted = $"{this._severity.ToString().ToUpperInvariant()} {this._category}: {message}";
+                this._parent._testOutputHelper.WriteLine( formatted );
+                this._parent.MessageReported?.Invoke( formatted );
             }
             catch
             {

--- a/Tests/Metalama.Backstage.Tests/ConfigurationManager/ConfigurationManagerLoadTests.cs
+++ b/Tests/Metalama.Backstage.Tests/ConfigurationManager/ConfigurationManagerLoadTests.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) SharpCrafters s.r.o. See the LICENSE.md file in the root directory of this repository root for details.
+
+using Metalama.Backstage.Configuration;
+using Metalama.Backstage.Diagnostics;
+using Metalama.Backstage.Infrastructure;
+using Metalama.Backstage.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Metalama.Backstage.Tests.ConfigurationManager;
+
+public class ConfigurationManagerLoadTests : TestsBase
+{
+    public ConfigurationManagerLoadTests( ITestOutputHelper logger ) : base( logger ) { }
+
+    [Fact]
+    public async Task ConcurrentConditionalUpdateSucceedsOnlyOnce()
+    {
+        // For this test, we want to use the "real" file system, not the simulation.
+
+        var services = new ServiceCollection();
+        services.AddSingleton<IFileSystem>( new FileSystem() );
+        services.AddSingleton<IDateTimeProvider>( this.Time );
+        services.AddSingleton<IEnvironmentVariableProvider>( this.EnvironmentVariableProvider );
+        services.AddSingleton<EarlyLoggerFactory>();
+        services.AddSingleton<IStandardDirectories>( s => new StandardDirectories( s ) );
+        var serviceProvider = services.BuildServiceProvider();
+
+        for ( var i = 0; i < 50; i++ )
+        {
+            var configurationManager = new Configuration.ConfigurationManager( serviceProvider );
+            configurationManager.Update<TestConfigurationFile>( f => f with { IsModified = false } );
+
+            bool UpdateImpl()
+            {
+                var myConfigurationManager = new Configuration.ConfigurationManager( serviceProvider );
+
+                return myConfigurationManager.UpdateIf<TestConfigurationFile>( f => !f.IsModified, f => f with { IsModified = true } );
+            }
+
+            var tasks = new[] { Task.Run( UpdateImpl ), Task.Run( UpdateImpl ) };
+
+            await Task.WhenAll( tasks );
+
+            var countTrue = tasks.Count( t => t.Result );
+            Assert.Equal( 1, countTrue );
+        }
+    }
+}

--- a/Tests/Metalama.Backstage.Tests/Diagnostics/DiagnosticsConfigurationTests.cs
+++ b/Tests/Metalama.Backstage.Tests/Diagnostics/DiagnosticsConfigurationTests.cs
@@ -24,6 +24,8 @@ public class DiagnosticsConfigurationTests : TestsBase
     [Fact]
     public void OutdatedConfiguration_DisablesLogging()
     {
+        this.Time.Stop();
+
         ( IServiceProvider ServiceProvider, string FileName ) BuildServiceProvider( Action<Configuration.ConfigurationManager>? configure = null )
         {
             var serviceCollection = this.CloneServiceCollection();
@@ -59,9 +61,11 @@ public class DiagnosticsConfigurationTests : TestsBase
         var logger1 = serviceProvider1.GetRequiredBackstageService<ILoggerFactory>().GetLogger( "Foo" );
         Assert.NotNull( logger1.Trace );
 
-        // Manually simulate the last modification of configuration happened before 3 hours.
         Assert.True( this.FileSystem.FileExists( fileName ) );
-        this.FileSystem.SetFileLastWriteTime( fileName, DateTime.Now.AddHours( -3 ) );
+
+        // Move the clock 3 hours later.
+        this.Time.AddTime( TimeSpan.FromHours( 3 ) );
+
         var (serviceProvider2, _) = BuildServiceProvider();
 
         var logger2 = serviceProvider2.GetRequiredBackstageService<ILoggerFactory>().GetLogger( "Foo" );

--- a/Tests/Metalama.Backstage.Tests/Licensing/Consumption/LicenseAuditTests.cs
+++ b/Tests/Metalama.Backstage.Tests/Licensing/Consumption/LicenseAuditTests.cs
@@ -102,7 +102,7 @@ public class LicenseAuditTests : LicenseConsumptionManagerTestsBase
             // Third time, one day later.
             this.FileSystem.Reset();
             this.HttpClientFactory.Reset();
-            this.Time.AddTime( TimeSpan.FromDays( 1 ) );
+            this.Time.AddTime( TimeSpan.FromDays( 1.01 ) );
 
             var thirdLicense = this.CreateAndConsumeLicense( licenseKey );
             Assert.True( thirdLicense.TryGetLicenseConsumptionData( out _, out _ ) );

--- a/Tests/Metalama.Backstage.Tests/UserInterface/ToastNotificationDetectionServiceTests.cs
+++ b/Tests/Metalama.Backstage.Tests/UserInterface/ToastNotificationDetectionServiceTests.cs
@@ -56,7 +56,7 @@ public class ToastNotificationDetectionServiceTests : LicensingTestsBase
         Assert.Empty( this.UserInterface.Notifications );
 
         // After the snooze period, we should see a notification.
-        this.Time.AddTime( ToastNotificationKinds.RequiresLicense.AutoSnoozePeriod );
+        this.Time.AddTime( ToastNotificationKinds.RequiresLicense.AutoSnoozePeriod.Add( TimeSpan.FromSeconds( 1 ) ) );
 
         await this.DetectToastNotificationsAsync( hasValidLicense );
 
@@ -104,7 +104,7 @@ public class ToastNotificationDetectionServiceTests : LicensingTestsBase
 #pragma warning restore CA1307
         }
     }
-    
+
     [Theory]
     [InlineData( 30, null )] // Before LicensingConstants.SubscriptionExpirationWarningPeriod
     [InlineData( 29, "29 days" )]


### PR DESCRIPTION
#35225 CLI tool: --verbose flag does not work
#35249 Telemetry: add timestamp and version to log
#35241 Telemetry: DeviceId not allocated, LastUploadTime never changes
#35250 Enable logging of errors by default
#35252 Logging may be always disabled on timezones with more than two hours of delay to UTC